### PR TITLE
Release 2.4.3 monthly Render refresh updates

### DIFF
--- a/VERSION.md
+++ b/VERSION.md
@@ -36,3 +36,4 @@
 * 2.4.0 - Documentation cleanup (moved detailed logs to Capstone_Project_Logs.md) and refreshed Render database to Postgres 18.  2026-01-28
 * 2.4.1 - Monthly Render database refresh and data reseed (Postgres 18).  Updated production maintenance documentation.  2026-02-22
 * 2.4.2 - Monthly Render database refresh and production redeploy runbook update.  2026-03-28
+* 2.4.3 - Monthly Render database refresh and production redeploy.  2026-05-01

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "project-movie-back-end",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "project-movie-back-end",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-movie-back-end",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "zid-be-project-movie-01-qualified",
   "main": "src/app.js",
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -17,7 +17,7 @@ const reviewsRouter = require("./reviews/reviews.router");
 // Add routes here
 app.get("/", (req, res) => {
     res.send("Welcome to the We Love Movies API Query Service!<br>" +
-        "Build: v2.4.2, using Node.js, Express, and PostgreSQL v18<br>" +
+        "Build: v2.4.3, using Node.js, Express, and PostgreSQL v18<br>" +
         "For more information, please visit: https://github.com/kernel528/WeLoveMovies<br>");
 });
 app.use("/movies", moviesRouter);


### PR DESCRIPTION
## Summary
- Increment release version metadata from `2.4.2` to `2.4.3` in `package.json` and `package-lock.json`.
- Update API root build banner to `v2.4.3` in `src/app.js`.
- Append `2.4.3` monthly Render refresh entry in `VERSION.md` dated 2026-05-01.
- Remove accidental local Codex resume context artifact from tracked files.

## Notes
- Monthly Render DB refresh was completed manually before this release metadata update.
- Did not run tests because this PR only updates version/documentation metadata.