### PR TITLE
Release backend 2.5.1 and update repo references

### DIFF
--- a/Monthly_Prod_Notes.md
+++ b/Monthly_Prod_Notes.md
@@ -1,7 +1,7 @@
 # We Love Movies
 
 ## Monthly Render DB Refresh Runbook
-Last updated: 2026-06-05
+Last updated: 2026-07-05
 
 ### Scope
 This runbook covers the monthly production refresh when Render free-tier Postgres is recreated, then migrations/seeds are reapplied, and both services are redeployed.
@@ -115,3 +115,4 @@ This runbook covers the monthly production refresh when Render free-tier Postgre
 - February 2026: v18.2 (monthly refresh + reseed)
 - March 2026: v18.3 (monthly refresh + reseed + runbook update)
 - June 2026: v18.4 (monthly refresh + automation + release 2.5.0)
+- July 2026: v18.4 (monthly refresh + validated release 2.5.1)

--- a/README.md
+++ b/README.md
@@ -1,17 +1,20 @@
-[![Latest Version](https://img.shields.io/github/v/tag/kernel528/WeLoveMovies)](https://github.com/kernel528/WeLoveMovies/releases/latest)
+[![Latest Version](https://img.shields.io/github/v/tag/kernel528/welovemovies-backend)](https://github.com/kernel528/welovemovies-backend/releases/latest)
 
 # Chegg Skills Back-end Web Development Capstone
 This repository contains the source code for the We Love Movies Capstone to the Chegg Skills Back-end Web Development Certificate Program.
 
 ## Current Baseline
 
-- Latest release: `2.5.0` (2026-06-05).
+- Latest release: `2.5.1` (2026-07-05).
+- Back-end repo: https://github.com/kernel528/welovemovies-backend
+- Front-end repo: https://github.com/kernel528/welovemovies-frontend
+- Local project root: `~/Projects/WeLoveMovies/`
 - Monthly operations runbook: `Monthly_Prod_Notes.md`.
 - Version history and release notes: `VERSION.md`.
 
 ### Front-end Setup
-- The starter-movie-front-end is a symlink in this repo to the fork from Chegg Skills located here: [starter-movie-frontend](https://github.com/kernel528/starter-movie-front-end). This was setup to test progress in addition to test cases.
-- Due to using the `qualified-attach` to sync local changes with qualified site, this previously defaulted to the `Final_Capstone_WeLoveMovies_Guild_Node_18_1` folder name before moving to repo root.
+- The front-end app now lives in the sibling repository `~/Projects/WeLoveMovies/welovemovies-frontend`.
+- Configure the front-end `REACT_APP_API_BASE_URL` to point at this deployed or local back-end API.
 
 ## Quickstart
 1. Install dependencies: `npm install`
@@ -34,7 +37,7 @@ Use `.env.sample` as the template for local and production-related environment v
 
 ## Project Structure
 ```plaintext
-WeLoveMovies/
+welovemovies-backend/
 ├── .env
 ├── .gitignore
 ├── knexfile.js
@@ -90,8 +93,6 @@ WeLoveMovies/
     ├── utils/
         ├── map-properties.js
         ├── reduce-properties.js
-├── starter-movie-front-end (symlink)
-├── starter-movie-front-end.old/
 └── test/
 ```
 
@@ -167,4 +168,4 @@ WeLoveMovies/
 - Validate with `npm test` and smoke checks before each monthly release PR.
 
 ## Implementation & Deployment Logs
-Detailed historical setup notes, route task logs, validation transcripts, and deployment steps are kept in `Capstone_Project_Logs.md`.
+Detailed historical setup notes, route task logs, validation transcripts, and deployment steps are kept in `docs/Capstone_Project_Logs.md`.

--- a/VERSION.md
+++ b/VERSION.md
@@ -38,3 +38,4 @@
 * 2.4.2 - Monthly Render database refresh and production redeploy runbook update.  2026-03-28
 * 2.4.3 - Monthly Render database refresh and production redeploy.  2026-05-01
 * 2.5.0 - Monthly Render database refresh automation, Postgres 18.4 cutover, and release workflow updates.  2026-06-05
+* 2.5.1 - Monthly Render database refresh and application repository reference updates.  2026-07-05

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "project-movie-back-end",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "project-movie-back-end",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "ISC",
       "dependencies": {
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "project-movie-back-end",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "zid-be-project-movie-01-qualified",
   "main": "src/app.js",
   "scripts": {

--- a/src/app.js
+++ b/src/app.js
@@ -17,8 +17,8 @@ const reviewsRouter = require("./reviews/reviews.router");
 // Add routes here
 app.get("/", (req, res) => {
     res.send("Welcome to the We Love Movies API Query Service!<br>" +
-        "Build: v2.5.0, using Node.js, Express, and PostgreSQL v18.4<br>" +
-        "For more information, please visit: https://github.com/kernel528/WeLoveMovies<br>");
+        "Build: v2.5.1, using Node.js, Express, and PostgreSQL v18.4<br>" +
+        "For more information, please visit: https://github.com/kernel528/welovemovies-backend<br>");
 });
 app.use("/movies", moviesRouter);
 app.use("/theaters", theatersRouter);


### PR DESCRIPTION
## Summary\n- Bump backend release metadata to 2.5.1 (package.json, package-lock.json, src/app.js, README.md, VERSION.md)\n- Update repo references from kernel528/WeLoveMovies to kernel528/welovemovies-backend\n- Add sibling frontend repo and local project root references\n- Record July 2026 monthly refresh in Monthly_Prod_Notes.md\n\n## Verification\n- Production smoke tests passed against deployed API\n- Frontend legacy build passed\n- Diff whitespace check passed